### PR TITLE
feat: make jieba-lua optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,16 @@
 
 ## 安装
 
+使用 [lazy.nvim](https://github.com/folke/lazy.nvim) 插件管理器:
+
 ```lua
--- dependency 可以不要
-  { 'noearc/leap-zh.nvim', dependencies = { 'noearc/jieba-lua' } }
+  {
+    'noearc/leap-zh.nvim',
+    dependencies = {
+      'https://codeberg.org/andyg/leap.nvim',
+      'noearc/jieba-lua', -- 可选: 启用jieba分词
+    },
+  }
 ```
 
 ## 键位

--- a/lua/leap-zh.lua
+++ b/lua/leap-zh.lua
@@ -1,4 +1,3 @@
-local jieba = require("jieba")
 local flypy_table = require("flypy")
 local M = {}
 
@@ -68,6 +67,7 @@ local parse = function(startline, endline)
 end
 
 local parse_jieba = function()
+	local jieba = require("jieba")
 	local cum_l = 1
 	local parsed = {}
 	local str = vim.api.nvim_get_current_line()


### PR DESCRIPTION
Problem:

  如果不安装 jieba-lua 就不能正常运行. 但是多数功能不依赖于 jieba-lua.

Solution:

  在调用需要 jieba-lua 的时候动态加载之. 性能损耗应该很小.